### PR TITLE
bugfix/Auth buttons click event

### DIFF
--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -45,6 +45,7 @@ type ButtonProps = React.ComponentProps<"button"> &
     rounded?: boolean;
     href?: string;
     target?: string;
+    preventDefault?: boolean;
   };
 
 function Button({
@@ -55,6 +56,8 @@ function Button({
   rounded = false,
   children,
   href,
+  onClick,
+  preventDefault = true,
   ...props
 }: ButtonProps) {
   const Comp = asChild ? Slot : "button";
@@ -66,6 +69,10 @@ function Button({
         buttonVariants({ variant, size, className }),
         rounded ? "rounded-full" : ""
       )}
+      onClick={(e) => {
+        if (preventDefault) e.preventDefault();
+        if (onClick) onClick(e);
+      }}
       {...props}
     >
       {href ? (<Link href={href} target={props.target}>{children}</Link>) : <>{children}</>}


### PR DESCRIPTION
None of the oauth buttons were working due to the page itself reloading on every click. To solve this I simply had to add `event.preventDefault()`.